### PR TITLE
Remove comment in command substitution in completion.zsh

### DIFF
--- a/shell/completion.zsh
+++ b/shell/completion.zsh
@@ -157,7 +157,6 @@ __fzf_generic_path_completion() {
       [ -z "$dir" ] && dir='.'
       [ "$dir" != "/" ] && dir="${dir/%\//}"
       matches=$(
-        # Declare and assign separately for older zsh versions.
         export FZF_DEFAULT_OPTS
         FZF_DEFAULT_OPTS=$(__fzf_defaults "--reverse --scheme=path" "${FZF_COMPLETION_OPTS-}")
         unset FZF_DEFAULT_COMMAND FZF_DEFAULT_OPTS_FILE


### PR DESCRIPTION
After 22adb6494f4957d0bcc29a821b738b4e5d5796a5, the Zsh completion using `**` fails.

```sh
$ cat **__fzf_generic_path_completion:23: bad pattern: #
```

The cause of this bug is that a comment is in the command substitution.